### PR TITLE
Migrate from LightGraphs to Graphs.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,8 @@ version = "0.2.2"
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 ImageMorphology = "787d08f9-d448-5407-9aad-5290dd7ab264"
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
@@ -22,21 +22,21 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 [compat]
 Clustering = "0.14"
 Distances = "0.9, 0.10"
+Graphs = "1.4"
 ImageMorphology = "0.2"
-LightGraphs = "1.3"
 MultivariateStats = "0.7,0.8"
 NearestNeighbors = "0.4"
 Optim = "1.3, 1.4"
 Setfield = "0.7"
-SimpleWeightedGraphs = "1.1"
+SimpleWeightedGraphs = "1.2"
 StatsBase = "0.32, 0.33"
 WriteVTK = "1.10"
 julia = "1.5"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test","CSV","DataFrames"]
+test = ["Test", "CSV", "DataFrames"]

--- a/src/Unfolding.jl
+++ b/src/Unfolding.jl
@@ -4,7 +4,7 @@ using Clustering: dbscan
 using DelimitedFiles
 using Distances
 using ImageMorphology: thinning
-using LightGraphs: connected_components, dijkstra_shortest_paths
+using Graphs: connected_components, dijkstra_shortest_paths
 using LinearAlgebra: Diagonal, Symmetric, cross, dot, eigen
 using MultivariateStats: PCA, dmat2gram, fit, projection
 using NearestNeighbors


### PR DESCRIPTION
As you my know, development of LightGraphs has been moved to [Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl). The announcement can be found [here](https://discourse.julialang.org/t/lightgraphs-jl-transition/69526/17?u=simonschoelly).

This PR migrates this package to Graphs.jl.